### PR TITLE
Correct data path on windows

### DIFF
--- a/docs/insomnia/application-data.md
+++ b/docs/insomnia/application-data.md
@@ -7,7 +7,7 @@ category-url: support
 
 Insomnia stores data in the following location, depending on the platform:
 
-* `%APPDATA%\Roaming\Insomnia` on **Windows**
+* `%APPDATA%\Insomnia` on **Windows**
 * `$XDG_CONFIG_HOME/Insomnia` or `~/.config/Insomnia` on **Linux**
 * `~/Library/Application\ Support/Insomnia` on **macOS**
 


### PR DESCRIPTION
### Summary
<!-- Description of PR, with any special instructions for your reviewers. -->
On windows, the environment variable `APPDATA` already points to AppData\Roaming, so the path to insomnia's data would actually be `%APPDATA%\Insomnia` instead of the already documented `%APPDATA%\Roaming\Insomnia`

### Reason
<!-- Why are you making this change? Can be a link to a Jira ticket, GH issue, 
Trello card, etc. -->
So people in the future can find the path easier

### Testing
<!-- How can your reviewers test your change? How did you test it? -->
Tried the original path documented, it didn't exist
Then I tried the path I provided, it did exist